### PR TITLE
Add backwards compat instance of semigroup to the monoid instance

### DIFF
--- a/library/Deque.hs
+++ b/library/Deque.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Deque where
 
 import Prelude hiding (foldr, foldr', foldl')
@@ -5,8 +6,8 @@ import Control.Applicative
 import Data.Foldable
 import Data.Traversable
 import Data.Maybe
-import Data.Monoid
-
+import Data.Monoid hiding ((<>))
+import Data.Semigroup as Sem
 
 -- |
 -- Double-ended queue (aka Dequeue or Deque) based on the head-tail linked list.
@@ -131,11 +132,16 @@ deriving instance Eq a => Eq (Deque a)
 
 deriving instance Show a => Show (Deque a)
 
+instance Sem.Semigroup (Deque a) where
+  (<>) = prepend
+
 instance Monoid (Deque a) where
   mempty =
     Deque [] []
+#if !(MIN_VERSION_base(4,11,0))
   mappend =
-    prepend
+    (<>)
+#endif
 
 instance Foldable Deque where
   foldr step init (Deque snocList consList) =


### PR DESCRIPTION
This adds a `Semigroup` instance for the `Monoid` instance, since these have been split up in GHC 8.4, in a backwards compatible way, as recommended by https://prime.haskell.org/wiki/Libraries/Proposals/SemigroupMonoid#Writingcompatiblecode.

It has been tested with the following stack resolvers:

- `nightly-2018-04-01` using GHC 8.4.1
- `lts-10.10` using GHC 8.2.2
- `lts-8.11` using GHC 8.0.2
