### PR TITLE
Add Monad.fail and MonadFail instance

### DIFF
--- a/deque.cabal
+++ b/deque.cabal
@@ -45,4 +45,5 @@ library
     base >= 4.6 && < 5
   if impl(ghc < 8.0)
     build-depends:
-      semigroups >= 0.11 && < 0.19
+      semigroups >= 0.11 && < 0.19,
+      fail       >= 4.9  && < 5

--- a/library/Deque.hs
+++ b/library/Deque.hs
@@ -3,6 +3,7 @@ module Deque where
 import Prelude hiding (foldr, foldr', foldl')
 import Control.Applicative
 import Control.Monad
+import Control.Monad.Fail as Fail
 import Data.Foldable
 import Data.Traversable
 import Data.Maybe
@@ -164,6 +165,7 @@ instance Monad Deque where
     pure
   m >>= f =
     fromList (toList m >>= toList . f)
+  fail = Fail.fail
 
 instance Alternative Deque where
   empty =
@@ -176,3 +178,6 @@ instance MonadPlus Deque where
     empty
   mplus =
     (<|>)
+
+instance Fail.MonadFail Deque where
+  fail _ = mempty


### PR DESCRIPTION
Should be in line with https://prime.haskell.org/wiki/Libraries/Proposals/MonadFail#Adaptingoldcode

tested with ghc 7.10.3, 8.0.2, 8.6.1